### PR TITLE
move urlencode from devDeps to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "levelgraph": "~0.8.2",
     "levelgraph-jsonld": "~0.3.1",
     "lodash": "^2.4.1",
-    "validator": "^3.12.0"
+    "validator": "^3.12.0",
+    "urlencode": "^0.2.0"
   },
   "devDependencies": {
     "chai": "~1.9.1",
@@ -38,7 +39,6 @@
     "level-test": "^1.6.3",
     "mocha": "~1.18.2",
     "nodemon": "~1.0.19",
-    "supertest": "^0.13.0",
-    "urlencode": "^0.2.0"
+    "supertest": "^0.13.0"
   }
 }


### PR DESCRIPTION
fixes "Error: Cannot find module 'urlencode'" when using this module as a dependency.
